### PR TITLE
[mce-dbus] Identify clients behind xdg-dbus-proxy

### DIFF
--- a/mce-dbus.h
+++ b/mce-dbus.h
@@ -281,11 +281,14 @@ typedef enum
     /** Freshly created */
     PEERSTATE_INITIAL,
 
-    /** Doing org.freedesktop.DBus.GetNameOwner */
+    /** Pending org.freedesktop.DBus.GetNameOwner */
     PEERSTATE_QUERY_OWNER,
 
-    /** org.freedesktop.DBus.GetConnectionUnixProcessID */
+    /** Pending org.freedesktop.DBus.GetConnectionUnixProcessID */
     PEERSTATE_QUERY_PID,
+
+    /** Pending org.sailfishos.sailjailed.Identify */
+    PEERSTATE_IDENTIFY,
 
     /** Owner known and available on D-Bus */
     PEERSTATE_RUNNING,

--- a/modules/display.c
+++ b/modules/display.c
@@ -4612,7 +4612,7 @@ mdy_blanking_evaluate_pause_timeout(void)
         }
         if( (submode & MCE_SUBMODE_TKLOCK) &&
             client->bpc_pid != topmost_window_pid ) {
-            mce_log(LL_DEBUG, "tklocked and client %s is not topmost", name);
+            mce_log(LL_WARN, "tklocked and client %s is not topmost", name);
             continue;
         }
 


### PR DESCRIPTION
Display blanks while recording video with lockscreen camera. This
happens because regular dbus client identification sees pid of
xdg-dbus-proxy process associated with the sandbox in whic the camera
application is running rather than pid of the camera application
itself and this does not match the topmost window pid reported by
lipstick.

Check client pid obtained via GetConnectionUnixProcessID. If it is
xdg-dbus-proxy, make an additional Identify call to query client
details from the proxy.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>