### PR TITLE
[charging] Auto-detect charging hysteresis controls. Fixes JB#57297

### DIFF
--- a/inifiles/charging.ini
+++ b/inifiles/charging.ini
@@ -11,6 +11,14 @@
 
 [Charging]
 
+# Devices with kernels that utilize
+# - POWER_SUPPLY_PROP_CHARGING_ENABLED
+# - POWER_SUPPLY_PROP_INPUT_SUSPEND
+# are detected automatically and do not need to be configured.
+#
+# If configuration data is present, it takes precedence over
+# autodetect logic.
+
 # Devices where kernel utilizes POWER_SUPPLY_PROP_CHARGING_ENABLED
 # For example: f5121 (Xperia X), l500d (Jolla C)
 


### PR DESCRIPTION
Adding device specific configuration files for all currently supported
device types would be burdensome task.

Add auto-detect logic for the two kernel types where enabling/disabling
charging is known to work.

If control path is defined in mce configuration files, auto-detect
logic is disabled.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>