### PR TITLE
[display] Allow configuration to override max_brightness. JB#57811

### DIFF
--- a/modules/display.h
+++ b/modules/display.h
@@ -41,6 +41,9 @@
 /** List of max backlight control files to try */
 # define MCE_CONF_MAX_BACKLIGHT_PATH             "MaxBrightnessPath"
 
+/** When present, content of max_brightness sysfs file is ignored */
+# define MCE_CONF_MAX_BACKLIGHT_VALUE            "MaxBrightnessValue"
+
 /** Default timeout for the high brightness mode; in seconds */
 # define DEFAULT_HBM_TIMEOUT                     1800    /* 30 min */
 


### PR DESCRIPTION
If brightness sysfs file value is a bitfield (for example high
bits could be used for selecting high brightness mode), values
in range from one to max_brightness do not correspond with
monotonically rising actual display brightness.

Make it possible override value reported in max_brightness sysfs
file by means of configuration file and thus exclude problematic
brightness value range.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>