### PR TITLE
[charging] Broadcast charging control state changes. JB#58812

### DIFF
--- a/mce.conf
+++ b/mce.conf
@@ -234,6 +234,9 @@
 		<allow send_destination="com.nokia.mce"
 		       send_interface="com.nokia.mce.request"
 		       send_member="get_charger_type"/>
+		<allow send_destination="com.nokia.mce"
+		       send_interface="com.nokia.mce.request"
+		       send_member="get_charging_state"/>
 
 		<allow send_destination="com.nokia.mce"
 		       send_interface="com.nokia.mce.request"

--- a/modules/charging.c
+++ b/modules/charging.c
@@ -348,6 +348,8 @@ mch_policy_set_charging_state(charging_state_t charging_state)
                     mch_charging_state == CHARGING_STATE_DISABLED ?
                     mch_control_disable_value :
                     mch_control_enable_value);
+
+    mch_dbus_send_charging_state(0);
 EXIT:
     return;
 }


### PR DESCRIPTION
Only initial charging control state is broadcast and even that is not made available to non-privileged clients.

Broadcast change signals also whenever charging state changes and allow all clients to receive such signal messages.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>