### PR TITLE
[battery-udev] Optionally track also extcon devices. JB#59448

### DIFF
--- a/inifiles/battery-udev-settings.ini
+++ b/inifiles/battery-udev-settings.ini
@@ -27,6 +27,21 @@
 #
 # RefreshOnNotify = false
 
+# For similar purposes mce can be instructed to track
+# USB state changes reported by extcon subsystem devices.
+#
+# On its own this is not overtly costly, but chances
+# are that when it is needed, also RefreshOnNotify=true
+# should be used.
+#
+# To enable:
+#
+# RefreshOnExtcon = true
+#
+# Default is:
+#
+# RefreshOnExtcon = false
+
 # Many/most of devices do not send udev notifications
 # on every battery capacity percent change. Most of the
 # times this is harmless. However it can also  cause


### PR DESCRIPTION
If battery and charger power_supply devices do not emit change notifications, also major changes like charger connect / disconnect can go unnoticed. While the situation does self correct as mce polls power_supply devices periodically, the polling is done in pace determined by process watchdog activity and thus recovery can take up to 36 seconds.

Add support for configuration option

  [BatteryUDevSettings]
  RefreshOnExtcon = true

Which makes mce track devices in extcon subsystem and poll power_supply devices also when changes in USB state are reported.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>