### PR TITLE
[charging] Use literal number for charging enable limit. Fixes JB#59821

### DIFF
--- a/modules/charging.h
+++ b/modules/charging.h
@@ -53,13 +53,19 @@
 # define MCE_SETTING_CHARGING_MODE              MCE_SETTING_CHARGING_PATH "/charging_mode"
 # define MCE_DEFAULT_CHARGING_MODE              1 // = CHARGING_MODE_ENABLE
 
-/** Battery level at which to disable charging */
+/** Battery level at which to disable charging
+ *
+ * The value is dictated by hardcoded expectations in settings ui.
+ */
 # define MCE_SETTING_CHARGING_LIMIT_DISABLE     MCE_SETTING_CHARGING_PATH "/limit_disable"
 # define MCE_DEFAULT_CHARGING_LIMIT_DISABLE     90
 
-/** Battery level at which to enable charging */
+/** Battery level at which to enable charging
+ *
+ * The value is dictated by hardcoded expectations in settings ui.
+ */
 # define MCE_SETTING_CHARGING_LIMIT_ENABLE      MCE_SETTING_CHARGING_PATH "/limit_enable"
-# define MCE_DEFAULT_CHARGING_LIMIT_ENABLE      (MCE_DEFAULT_CHARGING_LIMIT_DISABLE - 3)
+# define MCE_DEFAULT_CHARGING_LIMIT_ENABLE      87 // = MCE_DEFAULT_CHARGING_LIMIT_DISABLE - 3
 
 /* ========================================================================= *
  * Types


### PR DESCRIPTION
Default charging enable limit shows up as zero. This is because the values are stored in stringified form and then interpreted according to expected value type and strtol() returns zero for "(90 - 3)".

Switch to literal number as it used to be.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>