### PR TITLE
[charging] Add battery_charging_enabled to charging control. JB#61862

### DIFF
--- a/modules/charging.c
+++ b/modules/charging.c
@@ -693,6 +693,11 @@ static const struct {
     const char *disable_value;
 } mch_autoconfig[] = {
     {
+        .control_path  = "/sys/class/power_supply/battery/battery_charging_enabled",
+        .enable_value  = "1",
+        .disable_value = "0",
+    },
+    {
         .control_path  = "/sys/class/power_supply/battery/charging_enabled",
         .enable_value  = "1",
         .disable_value = "0",


### PR DESCRIPTION
Behavior of battery_charging_enabled is like charging_enabled except device will keep getting power from USB but won't charge the battery.