### PR TITLE
Add missing includes

### DIFF
--- a/event-input.c
+++ b/event-input.c
@@ -40,6 +40,7 @@
 # include "mce-setting.h"
 #endif
 #include "mce-sensorfw.h"
+#include "mce-wakelock.h"
 #include "multitouch.h"
 #include "evdev.h"
 

--- a/modules/battery-udev.c
+++ b/modules/battery-udev.c
@@ -32,6 +32,7 @@
 #include <mce/mode-names.h>
 
 #include <libudev.h>
+#include <libgen.h>
 
 #include <gmodule.h>
 

--- a/tools/dummy_compositor.c
+++ b/tools/dummy_compositor.c
@@ -28,6 +28,7 @@
 #include <errno.h>
 #include <syslog.h>
 #include <getopt.h>
+#include <libgen.h>
 
 #include <glib.h>
 

--- a/tools/evdev_trace.c
+++ b/tools/evdev_trace.c
@@ -35,6 +35,7 @@
 #include <poll.h>
 #include <glob.h>
 #include <getopt.h>
+#include <libgen.h>
 
 /** Flag for: emit event time stamps */
 static bool emit_event_time  = true;

--- a/tools/fileusers.c
+++ b/tools/fileusers.c
@@ -34,6 +34,7 @@
 #include <stdlib.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <libgen.h>
 
 /* ========================================================================= *
  * TYPES & FUNCTIONS


### PR DESCRIPTION
Missing includes are considered an error since GCC 14