### PR TITLE
[event-input] Allow numerical values in evdev event mapping. JB#49548

### DIFF
--- a/inifiles/evdev.ini
+++ b/inifiles/evdev.ini
@@ -30,6 +30,9 @@
 # SW_LID is keypad slide, not display cover
 #SW_LID=SW_KEYPAD_SLIDE
 
+# Device private KEY event code 252 is actually SW_LID
+#KEYCODE_252=SW_LID
+
 # This feature should be used only for SW_XXX -> SW_YYY mapping,
 # but for debugging purposes things like volume down = power key
 # can be used too (but only EV_SW and EV_KEY types are mapped).


### PR DESCRIPTION
Some devices send key events instead of standard switch events such as SW_LID. While MCE supports remapping of such evdev events, it currently requires that known event names are used in configuration files - which does not work for e.g. device specific custom key event codes.

Allow numerical event codes to be used in evdev mapping. Format is
  <KEYCODE|SWCODE|BTNCODE>'_'<NUMBER>

Where NUMBER can be decimal, hexadecimal or octal (e.g. 27 = 0x1b = 033).