### PR TITLE
[mce] Fix memnotify signaling properly storing the last value. JB#63136

### DIFF
--- a/mce-common.c
+++ b/mce-common.c
@@ -741,7 +741,7 @@ static void
 common_dbus_send_memnotify_level(void)
 {
     /* Initialize last seen value to something that is never used */
-    memnotify_level_t last = MEMNOTIFY_LEVEL_COUNT;
+    static memnotify_level_t last = MEMNOTIFY_LEVEL_COUNT;
 
     if( last != memnotify_level ) {
         last = memnotify_level;

--- a/mce-lib.c
+++ b/mce-lib.c
@@ -153,6 +153,7 @@ char *bitfield_to_string(const gulong *bitfield, gsize bitfieldsize)
 						       tmp, (i * bitsize_of(*bitfield)) + j);
 
 				g_free(tmp);
+				tmp = NULL;
 
 				if (tmp2 == NULL) {
 					mce_log(LL_CRIT,


### PR DESCRIPTION
And one theoretical case of returning already free()'d pointer.