### PR TITLE
Fix issues reported by clang scan-build

### DIFF
--- a/.depend
+++ b/.depend
@@ -1099,6 +1099,7 @@ modules/radiostates.o:\
 	mce-conf.h\
 	mce-dbus.h\
 	mce-io.h\
+	mce-lib.h\
 	mce-log.h\
 	mce.h\
 	musl-compatibility.h\
@@ -1111,6 +1112,7 @@ modules/radiostates.pic.o:\
 	mce-conf.h\
 	mce-dbus.h\
 	mce-io.h\
+	mce-lib.h\
 	mce-log.h\
 	mce.h\
 	musl-compatibility.h\

--- a/.depend
+++ b/.depend
@@ -336,7 +336,6 @@ mce-lib.o:\
 	mce-lib.c\
 	datapipe.h\
 	mce-lib.h\
-	mce-log.h\
 	mce-wakelock.h\
 	mce.h\
 	musl-compatibility.h\
@@ -345,7 +344,6 @@ mce-lib.pic.o:\
 	mce-lib.c\
 	datapipe.h\
 	mce-lib.h\
-	mce-log.h\
 	mce-wakelock.h\
 	mce.h\
 	musl-compatibility.h\

--- a/datapipe.c
+++ b/datapipe.c
@@ -6,6 +6,7 @@
  * Copyright (c) 2007 - 2008 Nokia Corporation and/or its subsidiary(-ies).
  * Copyright (c) 2014 - 2021 Jolla Ltd.
  * Copyright (c) 2019 - 2020 Open Mobile Platform LLC.
+ * Copyright (c) 2025 Jolla Mobile Ltd
  * <p>
  * @author David Weinehall <david.weinehall@nokia.com>
  * @author Simo Piiroinen <simo.piiroinen@jollamobile.com>
@@ -1439,12 +1440,6 @@ const char *submode_change_repr(submode_t prev, submode_t curr)
     char *pos = buff;
     char *end = buff + sizeof buff - 1;
 
-    auto inline void add(const char *str)
-    {
-        while( pos < end && *str )
-            *pos++ = *str++;
-    }
-
     for( int i = 0; lut[i].name; ++i ) {
         const char *tag = 0;
 
@@ -1456,13 +1451,14 @@ const char *submode_change_repr(submode_t prev, submode_t curr)
         }
 
         if( tag ) {
-            if( pos> buff ) add(" ");
-            add(tag);
-            add(lut[i].name);
+            if( pos > buff )
+                pos = mce_append_string(pos, end, " ");
+            pos = mce_append_string(pos, end, tag);
+            pos = mce_append_string(pos, end, lut[i].name);
         }
     }
     if( pos == buff ) {
-        add("NONE");
+        pos = mce_append_string(pos, end, "NONE");
     }
     *pos = 0;
     return buff;

--- a/evdev.c
+++ b/evdev.c
@@ -4,6 +4,7 @@
  * <p>
  * Copyright (c) 2012 - 2020 Jolla Ltd.
  * Copyright (c) 2020 Open Mobile Platform LLC.
+ * Copyright (c) 2025 Jolla Mobile Ltd
  * <p>
  * @author Simo Piiroinen <simo.piiroinen@jollamobile.com>
  *
@@ -290,7 +291,7 @@ int evdev_identify_device(int fd)
 
   // device name
   {
-    char name[256];;
+    char name[256];
     if( ioctl(fd, EVIOCGNAME(sizeof(name)), name) == -1 )
     {
       mce_log(LL_WARN, "%s: EVIOCGNAME: %m", path);

--- a/mce-command-line.c
+++ b/mce-command-line.c
@@ -3,7 +3,8 @@
  *
  * Command line parameter parsing module for the Mode Control Entity
  * <p>
- * Copyright © 2014 Jolla Ltd.
+ * Copyright (c) 2014 Jolla Ltd.
+ * Copyright (c) 2025 Jolla Mobile Ltd
  * <p>
  * @author Simo Piiroinen <simo.piiroinen@jollamobile.com>
  *
@@ -57,10 +58,15 @@ static void   mce_options_sanity_check(const mce_opt_t *opts);
 static bool
 mce_opt_handle(const mce_opt_t *self, char *arg)
 {
-    if( !arg )
-        return self->without_arg(0);
-
-    return self->with_arg(arg);
+    if( !arg ) {
+        if( self->without_arg )
+            return self->without_arg(NULL);
+    }
+    else {
+        if( self->with_arg )
+            return self->with_arg(arg);
+    }
+    return false;
 }
 
 static void

--- a/mce-dsme.c
+++ b/mce-dsme.c
@@ -4,8 +4,9 @@
  * DSME (the Device State Management Entity)
  * and MCE (the Mode Control Entity)
  * <p>
- * Copyright © 2004-2011 Nokia Corporation and/or its subsidiary(-ies).
- * Copyright © 2012-2019 Jolla Ltd.
+ * Copyright (c) 2004 - 2011 Nokia Corporation and/or its subsidiary(-ies).
+ * Copyright (c) 2012 - 2019 Jolla Ltd.
+ * Copyright (c) 2025 Jolla Mobile Ltd
  * <p>
  * @author David Weinehall <david.weinehall@nokia.com>
  * @author Ismo Laitinen <ismo.laitinen@nokia.com>
@@ -89,7 +90,7 @@ static system_state_t  mce_dsme_normalise_system_state (dsme_state_t dsmestate);
 
 static void           mce_dsme_worker_done_cb  (void *aptr, void *reply);
 static void          *mce_dsme_worker_pong_cb  (void *aptr);
-static void           mce_dsme_worker_ping     (void);;
+static void           mce_dsme_worker_ping     (void);
 
 /* ------------------------------------------------------------------------- *
  * PROCESS_WATCHDOG

--- a/mce-fbdev.c
+++ b/mce-fbdev.c
@@ -2,7 +2,8 @@
  * @file mce-fbdev.c
  * Frame buffer device handling code for the Mode Control Entity
  * <p>
- * Copyright 2015 Jolla Ltd.
+ * Copyright (c) 2015 Jolla Ltd.
+ * Copyright (c) 2025 Jolla Mobile Ltd
  * <p>
  * @author Simo Piiroinen <simo.piiroinen@jollamobile.com>
  *
@@ -292,7 +293,7 @@ void mce_fbdev_init(void)
     }
 #endif
     else {
-        mce_log(LL_NOTICE, "no fb power control available");;
+        mce_log(LL_NOTICE, "no fb power control available");
     }
 }
 

--- a/mce-io.c
+++ b/mce-io.c
@@ -2,8 +2,9 @@
  * @file mce-io.c
  * Generic I/O functionality for the Mode Control Entity
  * <p>
- * Copyright © 2006-2011 Nokia Corporation and/or its subsidiary(-ies).
- * Copyright (C) 2012-2019 Jolla Ltd.
+ * Copyright (c) 2006 - 2011 Nokia Corporation and/or its subsidiary(-ies).
+ * Copyright (c) 2012 - 2019 Jolla Ltd.
+ * Copyright (c) 2025 Jolla Mobile Ltd
  * <p>
  * @author David Weinehall <david.weinehall@nokia.com>
  * @author Santtu Lakkala <ext-santtu.1.lakkala@nokia.com>
@@ -389,23 +390,18 @@ const char *mce_io_condition_repr(GIOCondition cond)
 	char *end = buf + sizeof buf - 1;
 	char *pos = buf;
 
-	auto void add(const char *s);
-
-	auto void add(const char *s)
-	{
-		while( pos < end && *s ) *pos++ = *s++;
-	}
-
 	for( size_t i = 0; lut[i].bit; ++i ) {
 		if( cond & lut[i].bit ) {
 			cond ^= lut[i].bit;
-			if( pos > buf ) add("|");
-			add(lut[i].name);
+			if( pos > buf )
+				pos = mce_append_string(pos, end, "|");
+			pos = mce_append_string(pos, end, lut[i].name);
 		}
 	}
 	*pos = 0;
 	if( cond ) {
-		if( pos > buf ) add("|");
+		if( pos > buf )
+			pos = mce_append_string(pos, end, "|");
 		snprintf(pos, end - pos, "0x%x", cond);
 	}
 

--- a/mce-io.c
+++ b/mce-io.c
@@ -2046,7 +2046,7 @@ void *mce_io_load_file_until_eof(const char *path, size_t *psize)
 	data = g_malloc(size);
 
 	for( ;; ) {
-		rc = TEMP_FAILURE_RETRY(read(fd, data + used, size - used));;
+		rc = TEMP_FAILURE_RETRY(read(fd, data + used, size - used));
 
 		if( rc == 0 )
 			break;

--- a/mce-lib.c
+++ b/mce-lib.c
@@ -3,8 +3,9 @@
  * This file provides various helper functions
  * for the Mode Control Entity
  * <p>
- * Copyright © 2004-2011 Nokia Corporation and/or its subsidiary(-ies).
- * Copyright (C) 2014-2019 Jolla Ltd.
+ * Copyright (c) 2004 - 2011 Nokia Corporation and/or its subsidiary(-ies).
+ * Copyright (c) 2014 - 2019 Jolla Ltd.
+ * Copyright (c) 2025 Jolla Mobile Ltd
  * <p>
  * @author David Weinehall <david.weinehall@nokia.com>
  * @author Tapio Rantala <ext-tapio.rantala@nokia.com>
@@ -619,4 +620,15 @@ mce_slice_token(char *pos, char **ppos, const char *sep)
 	*ppos = pos;
 
     return mce_strip_string(beg);
+}
+
+char *
+mce_append_string(char *pos, char *end, const char *str)
+{
+    if( pos && str ) {
+	while( pos < end && *str )
+	    *pos++ = *str++;
+	*pos = 0;
+    }
+    return pos;
 }

--- a/mce-lib.h
+++ b/mce-lib.h
@@ -3,8 +3,9 @@
  * Headers for various helper functions
  * for the Mode Control Entity
  * <p>
- * Copyright © 2004-2011 Nokia Corporation and/or its subsidiary(-ies).
- * Copyright (C) 2014-2019 Jolla Ltd.
+ * Copyright (c) 2004 - 2011 Nokia Corporation and/or its subsidiary(-ies).
+ * Copyright (c) 2014 - 2019 Jolla Ltd.
+ * Copyright (c) 2025 Jolla Mobile Ltd
  * <p>
  * @author David Weinehall <david.weinehall@nokia.com>
  * @author Tapio Rantala <ext-tapio.rantala@nokia.com>
@@ -74,5 +75,6 @@ guint mce_wakelocked_idle_add(GSourceFunc function, gpointer data);
 
 char *mce_strip_string(char *str);
 char *mce_slice_token(char *pos, char **ppos, const char *sep);
+char *mce_append_string(char *pos, char *end, const char *str);
 
 #endif /* _MCE_LIB_H_ */

--- a/mce-lib.h
+++ b/mce-lib.h
@@ -32,7 +32,7 @@
 #include <glib.h>
 
 /** Find the number of bits of a type */
-#define bitsize_of(__x)			(guint)(sizeof (__x) * 8)
+#define bitsize_of(__x)			((guint)(sizeof (__x) * 8))
 
 /** translation structure */
 typedef struct {
@@ -46,7 +46,7 @@ gboolean test_bit(guint bit, const gulong *bitfield);
 
 gboolean string_to_bitfield(const gchar *string,
 			    gulong **bitfield, gsize bitfieldsize);
-char *bitfield_to_string(const gulong *bitfield, gsize bitfieldsize);
+gchar *bitfield_to_string(const gulong *bitfield, gsize bitfieldsize);
 
 const gchar *bin_to_string(guint bin);
 

--- a/mce-log.c
+++ b/mce-log.c
@@ -5,6 +5,7 @@
  * Copyright (c) 2006 - 2007, 2010 Nokia Corporation and/or its subsidiary(-ies).
  * Copyright (c) 2012 - 2020 Jolla Ltd.
  * Copyright (c) 2020 Open Mobile Platform LLC.
+ * Copyright (c) 2025 Jolla Mobile Ltd
  * <p>
  * @author David Weinehall <david.weinehall@nokia.com>
  * @author Simo Piiroinen <simo.piiroinen@jollamobile.com>
@@ -364,7 +365,7 @@ int mce_log_p_(loglevel_t loglevel,
 	switch( loglevel ) {
 	case LL_EXTRA:
 	case LL_CRUCIAL:
-		loglevel = LL_WARN;;
+		loglevel = LL_WARN;
 		break;
 	default:
 		break;

--- a/mce-sensorfw.c
+++ b/mce-sensorfw.c
@@ -6,7 +6,7 @@
  * <p>
  *
  * Copyright (c) 2013 - 2014 Jolla Ltd.
- * Copyright (c) 2025 Jollyboys Ltd.
+ * Copyright (c) 2025 Jolla Mobile Ltd
  *
  * <p>
  *
@@ -2016,15 +2016,18 @@ sfw_backend_als_sample_cb(sfw_plugin_t *plugin, sfw_notify_t type, const void *s
         break;
 
     case NOTIFY_EVDEV:
-        cached_value = *sample;
+        if( sample )
+            cached_value = *sample;
         break;
 
     case NOTIFY_SENSORD:
-        if( als_from_evdev() )
-            mce_log(LL_DEBUG, "ignoring sensord input: %s",
-                    sfw_sample_als_repr(sample));
-        else
-            cached_value = *sample;
+        if( sample ) {
+            if( als_from_evdev() )
+                mce_log(LL_DEBUG, "ignoring sensord input: %s",
+                        sfw_sample_als_repr(sample));
+            else
+                cached_value = *sample;
+        }
         break;
     }
 
@@ -2084,15 +2087,18 @@ sfw_backend_ps_sample_cb(sfw_plugin_t *plugin, sfw_notify_t type, const void *sa
         break;
 
     case NOTIFY_EVDEV:
-        cached_value = *sample;
+        if( sample )
+            cached_value = *sample;
         break;
 
     case NOTIFY_SENSORD:
-        if( ps_from_evdev() )
-            mce_log(LL_DEBUG, "ignoring sensord input: %s",
-                    sfw_sample_ps_repr(sample));
-        else
-            cached_value = *sample;
+        if( sample ) {
+            if( ps_from_evdev() )
+                mce_log(LL_DEBUG, "ignoring sensord input: %s",
+                        sfw_sample_ps_repr(sample));
+            else
+                cached_value = *sample;
+        }
         break;
     }
 
@@ -2159,7 +2165,8 @@ sfw_backend_orient_sample_cb(sfw_plugin_t *plugin, sfw_notify_t type, const void
 
     case NOTIFY_EVDEV:
     case NOTIFY_SENSORD:
-        cached_value = *sample;
+        if( sample )
+            cached_value = *sample;
         break;
     }
 

--- a/mce-worker.c
+++ b/mce-worker.c
@@ -5,7 +5,8 @@
  *
  * <p>
  *
- * Copyright (C) 2015 Jolla Ltd.
+ * Copyright (c) 2015 Jolla Ltd.
+ * Copyright (c) 2025 Jolla Mobile Ltd
  *
  * <p>
  *
@@ -442,7 +443,7 @@ mce_worker_has_context(const char *context)
         return true;
 
     if( !mw_ctx_lut )
-        return false;;
+        return false;
 
     return g_hash_table_lookup(mw_ctx_lut, context) != 0;
 }

--- a/modules/battery-upower.c
+++ b/modules/battery-upower.c
@@ -2,7 +2,8 @@
  * @file battery-upower.c
  * Battery module -- this implements battery and charger logic for MCE
  * <p>
- * Copyright (C) 2013 Jolla Ltd.
+ * Copyright (c) 2013 Jolla Ltd.
+ * Copyright (c) 2025 Jolla Mobile Ltd
  * <p>
  * @author Simo Piiroinen <simo.piiroinen@jollamobile.com>
  * <p>
@@ -290,7 +291,7 @@ static uprop_t * uprop_create(const char *key)
 {
     uprop_t *self = calloc(1, sizeof *self);
 
-    self->p_key  = strdup(key);;
+    self->p_key  = strdup(key);
     self->p_type = DBUS_TYPE_INVALID;
 
     return self;

--- a/modules/cpu-keepalive.c
+++ b/modules/cpu-keepalive.c
@@ -2,7 +2,8 @@
  * @file cpu-keepalive.c
  * cpu-keepalive module -- this implements late suspend blocking for MCE
  * <p>
- * Copyright (C) 2013-2019 Jolla Ltd.
+ * Copyright (c) 2013 - 2019 Jolla Ltd.
+ * Copyright (c) 2025 Jolla Mobile Ltd
  * <p>
  * @author Simo Piiroinen <simo.piiroinen@jollamobile.com>
  *
@@ -985,14 +986,13 @@ cka_clients_verify_name_cb(DBusPendingCall *pending, void *user_data)
   const gchar *name   = user_data;
   gchar       *owner  = 0;
   DBusMessage *rsp    = 0;
-  cka_client_t    *client = 0;
 
   if( !(rsp = dbus_pending_call_steal_reply(pending)) )
   {
     goto EXIT;
   }
 
-  if( !(client = cka_clients_get_client(name)) )
+  if( !cka_clients_get_client(name) )
   {
     mce_log(LL_WARN, "untracked client %s", name);
   }
@@ -1000,7 +1000,7 @@ cka_clients_verify_name_cb(DBusPendingCall *pending, void *user_data)
   if( !(owner = cka_dbusutil_parse_GetNameOwner_rsp(rsp)) || !*owner )
   {
     mce_log(LL_WARN, "dead client %s", name);
-    cka_clients_remove_client(name), client = 0;
+    cka_clients_remove_client(name);
   }
   else
   {

--- a/modules/display.c
+++ b/modules/display.c
@@ -5,7 +5,7 @@
  * Copyright (c) 2007 - 2011 Nokia Corporation and/or its subsidiary(-ies).
  * Copyright (c) 2012 - 2023 Jolla Ltd.
  * Copyright (c) 2020 Open Mobile Platform LLC.
- * Copyright (c) 2025 Jollyboys Ltd.
+ * Copyright (c) 2025 Jolla Mobile Ltd
  * <p>
  * @author David Weinehall <david.weinehall@nokia.com>
  * @author Tapio Rantala <ext-tapio.rantala@nokia.com>
@@ -3175,7 +3175,7 @@ static void mdy_brightness_fade_continue_with_als(fader_type_t fader_type)
         break;
 
     default:
-        goto EXIT;
+        break;
     }
 
     /* Apply if change is needed */

--- a/modules/doubletap.c
+++ b/modules/doubletap.c
@@ -2,7 +2,8 @@
  * @file doubletap.c
  * Doubletap control module -- this handles gesture enabling/disabling
  * <p>
- * Copyright (C) 2013-2019 Jolla Ltd.
+ * Copyright (c) 2013 - 2019 Jolla Ltd.
+ * Copyright (c) 2025 Jolla Mobile Ltd
  * <p>
  * @author Simo Piiroinen <simo.piiroinen@jollamobile.com>
  *
@@ -317,7 +318,7 @@ EXIT:
         if( !success ) {
                 g_free(sleep_mode_ctrl_path), sleep_mode_ctrl_path = 0;
                 g_free(sleep_mode_allow_val), sleep_mode_allow_val = 0;
-                g_free(sleep_mode_deny_val),  sleep_mode_deny_val  = 0;;
+                g_free(sleep_mode_deny_val),  sleep_mode_deny_val  = 0;
         }
         return;
 }

--- a/modules/filter-brightness-als.c
+++ b/modules/filter-brightness-als.c
@@ -4,8 +4,9 @@
  * for display backlight, key backlight, and LED brightness
  * This file implements a filter module for MCE
  * <p>
- * Copyright © 2007-2011 Nokia Corporation and/or its subsidiary(-ies).
- * Copyright © 2012-2019 Jolla Ltd.
+ * Copyright (c) 2007 - 2011 Nokia Corporation and/or its subsidiary(-ies).
+ * Copyright (c) 2012 - 2019 Jolla Ltd.
+ * Copyright (c) 2025 Jolla Mobile Ltd
  * <p>
  * @author David Weinehall <david.weinehall@nokia.com>
  * @author Tuomo Tanskanen <ext-tuomo.1.tanskanen@nokia.com>
@@ -603,7 +604,7 @@ fba_inputflt_dummy_reset(void)
 static int  fba_inputflt_median_fifo[FBA_INPUTFLT_MEDIAN_SIZE] = {  };
 
 /** Contents of fba_inputflt_median_fifo in ascending order */
-static int  fba_inputflt_median_stat[FBA_INPUTFLT_MEDIAN_SIZE] = {  };;
+static int  fba_inputflt_median_stat[FBA_INPUTFLT_MEDIAN_SIZE] = {  };
 
 static int
 fba_inputflt_median_filter(int add)

--- a/modules/radiostates.c
+++ b/modules/radiostates.c
@@ -2,8 +2,9 @@
  * @file radiostates.c
  * Radio state module for the Mode Control Entity
  * <p>
- * Copyright © 2010-2011 Nokia Corporation and/or its subsidiary(-ies).
- * Copyright (C) 2013-2019 Jolla Ltd.
+ * Copyright (c) 2010 - 2011 Nokia Corporation and/or its subsidiary(-ies).
+ * Copyright (c) 2013 - 2019 Jolla Ltd.
+ * Copyright (c) 2025 Jolla Mobile Ltd
  * <p>
  * @author David Weinehall <david.weinehall@nokia.com>
  * @author Santtu Lakkala <ext-santtu.1.lakkala@nokia.com>
@@ -25,6 +26,7 @@
 #include "radiostates.h"
 
 #include "../mce.h"
+#include "../mce-lib.h"
 #include "../mce-log.h"
 #include "../mce-io.h"
 #include "../mce-conf.h"
@@ -191,29 +193,22 @@ radio_states_change_repr(guint prev, guint curr)
 	char *pos = repr;
 	char *end = repr + sizeof repr - 1;
 
-	auto void add(const char *str) {
-		if( !str )
-			str = "(null)";
-		while( *str && pos < end )
-			*pos++ = *str++;
-	}
-
 	guint diff = prev ^ curr;
 
 	for( int i = 0; i < RADIO_STATES_COUNT; ++i ) {
 		guint mask = radio_state_flags[i];
 		if( (diff | curr) & mask ) {
 			if( diff & mask )
-				add((curr & mask) ? "+" : "-");
-			add(radio_state_repr[i]);
-			add(" ");
+				pos = mce_append_string(pos, end, (curr & mask) ? "+" : "-");
+			pos = mce_append_string(pos, end, radio_state_repr[i] ?: "(null)");
+			pos = mce_append_string(pos, end, " ");
 		}
 	}
 
 	if( pos > repr )
 		--pos;
 	else
-		add("(none)");
+		pos = mce_append_string(pos, end, "(none)");
 
 	*pos = 0;
 

--- a/powerkey.c
+++ b/powerkey.c
@@ -2,8 +2,9 @@
  * @file powerkey.c
  * Power key logic for the Mode Control Entity
  * <p>
- * Copyright © 2004-2011 Nokia Corporation and/or its subsidiary(-ies).
- * Copyright © 2013-2019 Jolla Ltd.
+ * Copyright (c) 2004 - 2011 Nokia Corporation and/or its subsidiary(-ies).
+ * Copyright (c) 2013 - 2019 Jolla Ltd.
+ * Copyright (c) 2025 Jolla Mobile Ltd
  * <p>
  * @author David Weinehall <david.weinehall@nokia.com>
  * @author Tapio Rantala <ext-tapio.rantala@nokia.com>
@@ -538,7 +539,6 @@ static void pwrkey_stm_rethink_wakelock     (void);
 
 static void pwrkey_stm_store_initial_state  (void);
 static void pwrkey_stm_terminate            (void);
-
 
 /* ------------------------------------------------------------------------- *
  * DBUS_IPC
@@ -1209,17 +1209,11 @@ pwrkey_mask_to_names(uint32_t mask)
     char *pos = tmp;
     char *end = tmp + sizeof tmp - 1;
 
-    auto void add(const char *str)
-    {
-        while( pos < end && *str )
-            *pos++ = *str++;
-    };
-
     for( size_t i = 0; i < G_N_ELEMENTS(pwrkey_action_lut); ++i ) {
         if( mask & (1u << i) ) {
             if( pos > tmp )
-                add(",");
-            add(pwrkey_action_lut[i].name);
+                pos = mce_append_string(pos, end, ",");
+            pos = mce_append_string(pos, end, pwrkey_action_lut[i].name);
         }
     }
     *pos = 0;
@@ -1633,6 +1627,16 @@ pwrkey_actions_do_long_press(void)
     }
 }
 
+static inline void
+pwrkey_actions_update_sub(bool *changed, char **prev, uint32_t mask, uint32_t unblanked)
+{
+    /* "unblanked" is internal thing, sanitize settings */
+    gchar *curr = pwrkey_mask_to_names(mask & ~unblanked);
+    if( prev && !eq(*prev, curr) )
+        *changed = true, g_free(*prev), *prev = curr, curr = NULL;
+    g_free(curr);
+}
+
 static bool
 pwrkey_actions_update(const pwrkey_actions_t *self,
                       gchar **names_single,
@@ -1643,18 +1647,9 @@ pwrkey_actions_update(const pwrkey_actions_t *self,
 
     uint32_t unblanked = pwrkey_mask_from_name("unblanked");
 
-    auto void update(gchar **prev, uint32_t mask)
-    {
-        /* "unblanked" is internal thing, sanitize settings */
-        gchar *curr = pwrkey_mask_to_names(mask & ~unblanked);
-        if( prev && !eq(*prev, curr) )
-            changed = true, g_free(*prev), *prev = curr, curr = 0;
-        g_free(curr);
-    }
-
-    update(names_single, self->mask_single | self->mask_common);
-    update(names_double, self->mask_double | self->mask_common);
-    update(names_long, self->mask_long);
+    pwrkey_actions_update_sub(&changed, names_single, self->mask_single | self->mask_common, unblanked);
+    pwrkey_actions_update_sub(&changed, names_double, self->mask_double | self->mask_common, unblanked);
+    pwrkey_actions_update_sub(&changed, names_long, self->mask_long, unblanked);
 
     return changed;
 }

--- a/powerkey.c
+++ b/powerkey.c
@@ -2866,11 +2866,11 @@ pwrkey_setting_quit(void)
         pwrkey_actions_double_off = 0;
 
     g_free(pwrkey_actions_long_off),
-        pwrkey_actions_long_off = 0;;
+        pwrkey_actions_long_off = 0;
 
     for( size_t i = 0; i < POWERKEY_ACTIONS_GESTURE_COUNT; ++i ) {
         g_free(pwrkey_actions_gesture[i]),
-            pwrkey_actions_gesture[i] = 0;;
+            pwrkey_actions_gesture[i] = 0;
     }
 
     /* Cancel pending delayed setting sanitizing */
@@ -2885,8 +2885,7 @@ pwrkey_setting_quit(void)
             action->setting_id = 0;
 
         g_free(action->setting_val),
-            action->setting_val = 0;;
-
+            action->setting_val = 0;
     }
 }
 

--- a/tklock.c
+++ b/tklock.c
@@ -5,7 +5,7 @@
  * <p>
  * Copyright (c) 2004 - 2011 Nokia Corporation and/or its subsidiary(-ies).
  * Copyright (c) 2012 - 2019 Jolla Ltd.
- * Copyright (c) 2025 Jollyboys Ltd.
+ * Copyright (c) 2025 Jolla Mobile Ltd
  * <p>
  * @author David Weinehall <david.weinehall@nokia.com>
  * @author Tapio Rantala <ext-tapio.rantala@nokia.com>
@@ -392,7 +392,7 @@ static void     tklock_ui_get_devicelock(void);
 static void     tklock_ui_send_lpm_signal(void);
 static void     tklock_ui_enable_lpm(void);
 static void     tklock_ui_disable_lpm(void);
-static void     tklock_ui_show_device_unlock(void);;
+static void     tklock_ui_show_device_unlock(void);
 
 // dbus ipc
 

--- a/tools/mcetool.c
+++ b/tools/mcetool.c
@@ -4,7 +4,7 @@
  * Copyright (c) 2005 - 2011 Nokia Corporation and/or its subsidiary(-ies).
  * Copyright (c) 2012 - 2022 Jolla Ltd.
  * Copyright (c) 2019 - 2020 Open Mobile Platform LLC.
- * Copyright (c) 2025 Jollyboys Ltd.
+ * Copyright (c) 2025 Jolla Mobile Ltd
  * <p>
  * @author David Weinehall <david.weinehall@nokia.com>
  * @author Santtu Lakkala <ext-santtu.1.lakkala@nokia.com>
@@ -442,6 +442,7 @@ int                 main                     (int argc, char **argv);
 
 static gboolean   mcetool_parse_timspec     (struct timespec *ts, const char *args);
 static char      *mcetool_parse_token       (char **ppos);
+static char      *mcetool_append_string     (char *pos, char *end, const char *str);
 static char      *mcetool_format_bitmask    (const symbol_t *lut, int mask, char *buff, size_t size);
 static unsigned   mcetool_parse_bitmask     (const symbol_t *lut, const char *args);
 static bool       mcetool_show_led_patterns (const char *args);
@@ -2250,6 +2251,16 @@ static char *mcetool_parse_token(char **ppos)
 
 }
 
+static char *mcetool_append_string(char *pos, char *end, const char *str)
+{
+    if( pos && str ) {
+        while( pos < end && *str )
+            *pos++ = *str++;
+        *pos = 0;
+    }
+    return pos;
+}
+
 /** Convert bitmap to human readable string via lookup table
  *
  * @param lut  array of symbol_t objects
@@ -2267,16 +2278,10 @@ static char *mcetool_format_bitmask(const symbol_t *lut, int mask,
         char *pos = buff;
         char *end = buff + size - 1;
 
-        auto void add(const char *str)
-        {
-                if( pos > buff && pos < end )
-                        *pos++ = ',';
-                while( pos < end && *str )
-                        *pos++ = *str++;
-        }
-
         if( !mask ) {
-                add(none);
+                if( pos > buff )
+                        pos = mcetool_append_string(pos, end, ",");
+                pos = mcetool_append_string(pos, end, none);
                 goto EXIT;
         }
 
@@ -2287,14 +2292,18 @@ static char *mcetool_format_bitmask(const symbol_t *lut, int mask,
                 const char *name = rlookup(lut, bit);
                 if( name ) {
                         mask &= ~bit;
-                        add(name);
+                        if( pos > buff )
+                                pos = mcetool_append_string(pos, end, ",");
+                        pos = mcetool_append_string(pos, end, name);
                 }
         }
 
         if( mask ) {
                 char hex[32];
                 snprintf(hex, sizeof hex, "0x%u", (unsigned)mask);
-                add(hex);
+                if( pos > buff )
+                        pos = mcetool_append_string(pos, end, ",");
+                pos = mcetool_append_string(pos, end, hex);
         }
 EXIT:
         *pos = 0;
@@ -8591,7 +8600,7 @@ PROG_NAME" v"G_STRINGIFY(PRG_VERSION)"\n"
 "Copyright (c) 2005 - 2011 Nokia Corporation.  All rights reserved.\n"
 "Copyright (c) 2012 - 2022 Jolla Ltd.\n"
 "Copyright (c) 2019 - 2020 Open Mobile Platform LLC.\n"
-"Copyright (c) 2025 Jollyboys Ltd.\n"
+"Copyright (c) 2025 Jolla Mobile Ltd\n"
 ;
 
 static __attribute__((__noreturn__)) bool mcetool_do_version(const char *arg)

--- a/tools/mcetool.c
+++ b/tools/mcetool.c
@@ -5664,7 +5664,7 @@ static void xmce_get_powerkey_dbus_action(size_t action_id)
                 printf("\t%-"PAD2"s   %s '%s'\n", "", "interface", interface);
                 printf("\t%-"PAD2"s   %s '%s'\n", "", "member", member);
                 printf("\t%-"PAD2"s   %s '%s'\n", "", "argument",
-                       *argument ? argument : "N/A");;
+                       *argument ? argument : "N/A");
         }
 
 cleanup:


### PR DESCRIPTION
Issues reported by "sb2 scan-build -o clang-build2 make -j8" were:

```
datapipe.c:1443:5: error: function definition is not allowed here
powerkey.c:1213:5: error: function definition is not allowed here
powerkey.c:1647:5: error: function definition is not allowed here
mce-io.c:392:2: error: illegal storage class on function
mce-io.c:395:2: error: function definition is not allowed here
libwakelock.c:61:24: error: function definition is not allowed here
libwakelock.c:92:32: error: function definition is not allowed here
libwakelock.c:119:2: error: function definition is not allowed here
modules/radiostates.c:194:33: error: function definition is not allowed here
mce-command-line.c:61:16: warning: Called function pointer is null (null dereference) [core.CallAndMessage]
mce-command-line.c:63:12: warning: Called function pointer is null (null dereference) [core.CallAndMessage]
mce-sensorfw.c:1293:14: warning: Access to field 'als_timestamp' results in a dereference of a null pointer (loaded from variable 'self') [core.NullDereference]
mce-sensorfw.c:1304:14: warning: Access to field 'ps_timestamp' results in a dereference of a null pointer (loaded from variable 'self') [core.NullDereference]
mce-sensorfw.c:2019:24: warning: Dereference of null pointer (loaded from variable 'sample') [core.NullDereference]
mce-sensorfw.c:2027:28: warning: Dereference of null pointer (loaded from variable 'sample') [core.NullDereference]
mce-sensorfw.c:2087:24: warning: Dereference of null pointer (loaded from variable 'sample') [core.NullDereference]
mce-sensorfw.c:2095:28: warning: Dereference of null pointer (loaded from variable 'sample') [core.NullDereference]
mce-sensorfw.c:2162:24: warning: Dereference of null pointer (loaded from variable 'sample') [core.NullDereference]
tools/mcetool.c:2271:9: error: function definition is not allowed here
modules/cpu-keepalive.c:995:9: warning: Although the value stored to 'client' is used in the enclosing expression, the value is never actually read from 'client' [deadcode.DeadStores]
mce-dbus.c:3888:10: warning: Null pointer passed to 2nd parameter expecting 'nonnull' [core.NonNullParamChecker]
modules/display.c:3162:9: warning: Value stored to 'level' during its initialization is never read [deadcode.DeadStores]
```