### PR TITLE
[display] Fix HBM and make it's path configurable

### DIFF
--- a/modules/display.c
+++ b/modules/display.c
@@ -5611,6 +5611,27 @@ static display_type_t mdy_display_type_get(void)
 
     mce_log(LL_DEBUG, "Display type: %d", display_type);
 
+    if( display_type != DISPLAY_TYPE_NONE ) {
+        gchar **hbmdir = mce_conf_get_string_list(MCE_CONF_DISPLAY_GROUP,
+                                                  MCE_CONF_HBM_CONTROL_PATH, 0);
+
+        if( hbmdir ) {
+            for( size_t i = 0; hbmdir[i]; ++i ) {
+                if( !*hbmdir[i] || g_access(hbmdir[i], W_OK) )
+                    continue;
+
+                g_free((void*)mdy_high_brightness_mode_output.path);
+
+                mdy_high_brightness_mode_output.path = g_strdup(hbmdir[i]);
+                mdy_high_brightness_mode_supported = TRUE;
+
+                break;
+            }
+        }
+
+        g_strfreev(hbmdir);
+    }
+
 EXIT:
     return display_type;
 }

--- a/modules/display.h
+++ b/modules/display.h
@@ -41,6 +41,9 @@
 /** List of max backlight control files to try */
 # define MCE_CONF_MAX_BACKLIGHT_PATH             "MaxBrightnessPath"
 
+/** Path to the SysFS entry for the HBM control */
+# define MCE_CONF_HBM_CONTROL_PATH               "HBMControlPath"
+
 /** Default timeout for the high brightness mode; in seconds */
 # define DEFAULT_HBM_TIMEOUT                     1800    /* 30 min */
 


### PR DESCRIPTION
So, I discovered that my phone has HBM and that HBM is a thing and that MCE has HBM support but it doesn't work. So first I've investigated the `mdy_display_type_get` method and my phone lands on the `mdy_display_type_get_from_sysfs_probe` method. Path `/sys/class/graphics/fb0/device/panel` doesn't exist and `/sys/class/backlight` is just empty. So then it gets brightness and max_brightness value but never gets HBM path which does exist in `/sys/class/graphics/fb0/hbm` so `device/panel` was close. So in `mdy_display_type_get_from_config` I added fetching the config for HBM and enabling it (if its wrong place I can move it) and I thought that would be it! But sadly, it wasn't.

So the method that decides whether or not to enable hbm is here https://github.com/sailfishos/mce/blob/master/modules/display.c#L3705 it takes first 8 bits as brightness and other 8 bits as hbm? Now that is very strange because at 255 it will be max brightness and no hbm but at 256 it will enable hbm and set brightness to 0? That makes no sense. And if it goes any higher HBM won't accept input as it only accepts 0/1. But that's not the only strange thing. Another one is that the input is CAPPED AT 100 https://github.com/sailfishos/mce/blob/master/modules/display.c#L11726 so HBM won't ever be enabled!

Maybe its legacy code I don't know but I've fixed that too and now it works fine