### PR TITLE
Add support for external suspend

### DIFF
--- a/inifiles/suspend.ini
+++ b/inifiles/suspend.ini
@@ -1,0 +1,11 @@
+# Configuration file for MCE - Suspend support
+
+[Suspend]
+
+# By default, MCE determines the support for suspend mode based on the kernel's sysfs
+# interface. Option External allows overriding this selection and preferring suspending
+# through some external daemon. Example use is with android.system.suspend-service.
+# Uncomment this option if your kernel has autosleep support (/sys/power/autosleep)
+# or early suspend support but you prefer to offload suspend to an external service.
+#
+# External=true

--- a/libwakelock.c
+++ b/libwakelock.c
@@ -270,7 +270,8 @@ suspend_type_t lwl_probe(void)
 		suspend_type = SUSPEND_TYPE_AUTO;
 	}
 	else  {
-		suspend_type = SUSPEND_TYPE_NONE;
+		/* Only wakelock controls available - assuming external autosleep */
+		suspend_type = SUSPEND_TYPE_EXTERN;
 	}
 
 EXIT:

--- a/libwakelock.c
+++ b/libwakelock.c
@@ -27,12 +27,19 @@
 
 #include "libwakelock.h"
 
+#include "mce-conf.h"
+
 #include <stdarg.h>
 #include <stdbool.h>
 #include <unistd.h>
 #include <string.h>
 #include <errno.h>
 #include <fcntl.h>
+
+#define MCE_CONF_SUSPEND_GROUP         "Suspend"
+
+#define MCE_CONF_SUSPEND_EXTERN        "External"
+
 
 /** Whether to write debug logging to stderr
  *
@@ -153,6 +160,9 @@ static void lwl_debug_(const char *m, ...)
 /** Flag that gets set once the process is about to exit */
 static int        lwl_shutting_down = 0;
 
+/** Flag that prefers external suspend to the other modes **/
+static int        lwl_force_extern = 0;
+
 /** Sysfs entry for acquiring wakelocks */
 static const char lwl_lock_path[]   = "/sys/power/wake_lock";
 
@@ -260,6 +270,10 @@ suspend_type_t lwl_probe(void)
 	if( access(lwl_lock_path, W_OK) || access(lwl_unlock_path, W_OK) ) {
 		/* No suspend without wakelock controls */
 		suspend_type = SUSPEND_TYPE_NONE;
+	}
+	else if( lwl_force_extern ) {
+		/* Configuration preference */
+		suspend_type = SUSPEND_TYPE_EXTERN;
 	}
 	else if( lwl_write_data(lwl_state_path, &data_on) ) {
 		/* No error from disabling early suspend */
@@ -388,4 +402,12 @@ void wakelock_block_suspend_until_exit(void)
 void lwl_enable_logging(void)
 {
 	lwl_debug_enabled = 1;
+}
+
+/** Load module configuration
+ */
+void lwl_init(void)
+{
+	lwl_force_extern = mce_conf_get_bool(MCE_CONF_SUSPEND_GROUP,
+		MCE_CONF_SUSPEND_EXTERN, false);
 }

--- a/libwakelock.h
+++ b/libwakelock.h
@@ -38,11 +38,14 @@ typedef enum {
     /* Suspend not supported */
     SUSPEND_TYPE_NONE  =  0,
 
+    /* External suspend model */
+    SUSPEND_TYPE_EXTERN =  1,
+
     /* Early suspend model */
-    SUSPEND_TYPE_EARLY =  1,
+    SUSPEND_TYPE_EARLY =  2,
 
     /* Autosleep model */
-    SUSPEND_TYPE_AUTO  =  2,
+    SUSPEND_TYPE_AUTO  =  3,
 } suspend_type_t;
 
 void wakelock_lock  (const char *name, long long ns);

--- a/libwakelock.h
+++ b/libwakelock.h
@@ -55,6 +55,7 @@ void wakelock_allow_suspend(void);
 void wakelock_block_suspend(void);
 void wakelock_block_suspend_until_exit(void);
 
+void lwl_init(void);
 void lwl_enable_logging(void);
 suspend_type_t lwl_probe(void);
 

--- a/mce.c
+++ b/mce.c
@@ -1044,6 +1044,11 @@ int main(int argc, char **argv)
 	/* Open fbdev as early as possible */
 	mce_fbdev_init();
 
+#ifdef ENABLE_WAKELOCKS
+    /* Initialize libwakelock */
+	lwl_init();
+#endif
+
 	/* Start worker thread */
 	if( !mce_worker_init() )
 		goto EXIT;

--- a/modules/display.c
+++ b/modules/display.c
@@ -5883,7 +5883,7 @@ static gboolean mdy_waitfb_thread_start(waitfb_t *self)
 
     mdy_waitfb_thread_stop(self);
 
-    if( lwl_probe() == SUSPEND_TYPE_AUTO )
+    if( lwl_probe() == SUSPEND_TYPE_AUTO || lwl_probe() == SUSPEND_TYPE_EXTERN )
         goto EXIT;
 
     if( access(self->wake_path, F_OK) == -1 ||


### PR DESCRIPTION
This PR adds one more type of suspend -- SUSPEND_TYPE_EXTERN -- and allows to prefer it to otherwise determined one. SUSPEND_TYPE_EXTERN relies on external service to suspend the device while taking into account wakelocks. An example service is android.system.suspend-service that, in addition to kernel wakelocks, is using wakelocks provided by itself. The latter ones are used by some Android services and include qcrild.

For use of Android suspend service in practice, it has to be activated. Example script handling activation could be 

```sh
#!/bin/sh
#
# Controls Android suspend service via binder interface
#

BINDER_DEVICE="/dev/binder"
SERVICE_NAME="suspend_control_internal"

print_usage() {
    cat << EOF
Usage: $(basename "$0") [OPTION]

Control Android system suspend functionality via binder interface.

Options:
  --enable        Enable automatic system suspension
  --disable       Disable automatic system suspension
  --verbose       Enable verbose logging for suspend operations
  --no-verbose    Disable verbose logging for suspend operations
  -h, --help      Show this help message

Examples:
  $(basename "$0") --enable
  $(basename "$0") --disable
  $(basename "$0") --verbose

EOF
}

call_binder() {
    local method_code="$1"
    local method_name="$2"
    
    echo "Calling ${method_name}..."
    
    binder-call -a -d "$BINDER_DEVICE" "$SERVICE_NAME" "$method_code"

    return 0
}

# Check if no arguments provided
if [ $# -eq 0 ]; then
    echo "Error: No option specified" >&2
    echo ""
    print_usage
    exit 1
fi

# Parse command line arguments
case "$1" in
    --enable)
        call_binder 1 "enableAutosuspend"
        exit $?
        ;;
    --disable)
        call_binder 2 "disableAutosuspend"
        exit $?
        ;;
    --verbose)
        call_binder 3 "enableVerbose"
        exit $?
        ;;
    --no-verbose)
        call_binder 4 "disableVerbose"
        exit $?
        ;;
    -h|--help)
        print_usage
        exit 0
        ;;
    *)
        echo "Error: Unknown option '$1'" >&2
        echo ""
        print_usage
        exit 1
        ;;
esac
```