### PR TITLE
[charging] Follow charging state to reset limits

### DIFF
--- a/modules/charging.c
+++ b/modules/charging.c
@@ -439,7 +439,7 @@ mch_policy_evaluate_charging_state(void)
     if( limit_disable <= limit_enable )
         limit_disable = 100;
 
-    if( usb_cable_state == USB_CABLE_DISCONNECTED ) {
+    if( charger_state != CHARGER_STATE_ON ) {
         /* Clear battery full seen on disconnect */
         mch_policy_set_battery_full(false);
 


### PR DESCRIPTION
When using wireless charging, USB cable is not connected during charging. Follow charger state instead to cover any technique used to charge the device