### PR TITLE
Treat non-zero values as true in online and present properties

### DIFF
--- a/modules/battery-udev.c
+++ b/modules/battery-udev.c
@@ -1618,7 +1618,7 @@ udevdevice_evaluate_charger(udevdevice_t *self, mcebat_t *mcebat)
      * we ought to be able to charge when either one gets
      * non-zero value ... */
 
-    bool active = (present == 1 || online == 1);
+    bool active = (present > 0 || online > 0);
 
     if( active ) {
         mcebat->charger_state = CHARGER_STATE_ON;


### PR DESCRIPTION
Some devices, such as MediaTek devices, use a special charger type value as online value with 0 meaning no charger and other values meaning different types of chargers. Change both to check for non-zero values for consistent behavior.