### PR TITLE
Start mce after systemd-modules-load service

### DIFF
--- a/systemd/mce.service
+++ b/systemd/mce.service
@@ -4,6 +4,7 @@ DefaultDependencies=no
 Requires=dbus.socket
 After=dbus.socket
 After=local-fs.target
+After=systemd-modules-load.service
 Before=basic.target
 Conflicts=shutdown.target
 


### PR DESCRIPTION
New Android versions build LED kernel driver as module and for LED to work reliably mce has to wait until for all modules have been loaded.