### PR TITLE
[tklock] Optional LID sensor feedback. JB#64921

### DIFF
--- a/builtin-gconf.c
+++ b/builtin-gconf.c
@@ -1338,6 +1338,11 @@ static const setting_t gconf_defaults[] =
     .def  = G_STRINGIFY(MCE_DEFAULT_TK_LID_SENSOR_ENABLED),
   },
   {
+    .key  = MCE_SETTING_TK_LID_SENSOR_FEEDBACK,
+    .type = "b",
+    .def  = G_STRINGIFY(MCE_DEFAULT_TK_LID_SENSOR_FEEDBACK),
+  },
+  {
     .key  = MCE_SETTING_TK_FILTER_LID_WITH_ALS,
     .type = "b",
     .def  = G_STRINGIFY(MCE_DEFAULT_TK_FILTER_LID_WITH_ALS),

--- a/powerkey.c
+++ b/powerkey.c
@@ -3372,14 +3372,15 @@ xngf_status_cb(NgfClient *client, uint32_t event_id, NgfEventState state, void *
         break;
 
     case NGF_EVENT_COMPLETED:
-        ngf_event_id = 0;
+        if( ngf_event_id == event_id )
+            ngf_event_id = 0;
         break;
 
     case NGF_EVENT_FAILED:
         mce_log(LL_ERR, "Failed to play id %d", event_id);
-        ngf_event_id = 0;
+        if( ngf_event_id == event_id )
+            ngf_event_id = 0;
         break;
-
     }
 }
 
@@ -3427,13 +3428,14 @@ xngf_delete_client(void)
 static void
 xngf_play_event(const char *event_name)
 {
-    if( ngf_event_id ) {
-        mce_log(LL_WARN, "previous event not finished yet");
-        goto EXIT;
-    }
-
     if( !xngf_create_client() )
         goto EXIT;
+
+    if( ngf_event_id ) {
+        mce_log(LL_WARN, "previous event not finished yet, canceling it");
+        ngf_client_stop_event(ngf_client_hnd, ngf_event_id),
+            ngf_event_id = 0;
+    }
 
     ngf_event_id = ngf_client_play_event (ngf_client_hnd, event_name, NULL);
 

--- a/tklock.c
+++ b/tklock.c
@@ -510,6 +510,10 @@ static guint tklock_lid_close_actions_setting_id = 0;
 static gboolean lid_sensor_enabled = MCE_DEFAULT_TK_LID_SENSOR_ENABLED;
 static guint    lid_sensor_enabled_setting_id = 0;
 
+/** Flag: Should we trigger feedback on lid sensor state changes */
+static gboolean lid_sensor_feedback = MCE_DEFAULT_TK_LID_SENSOR_FEEDBACK;
+static guint    lid_sensor_feedback_setting_id = 0;
+
 /** When to react to keyboard open */
 static gint   tklock_kbd_open_trigger = MCE_DEFAULT_TK_KBD_OPEN_TRIGGER;
 static guint  tklock_kbd_open_trigger_setting_id = 0;
@@ -2207,6 +2211,13 @@ static void tklock_datapipe_lid_sensor_filtered_cb(gconstpointer data)
     mce_log(LL_DEVEL, "lid_sensor_filtered = %s -> %s",
             cover_state_repr(prev),
             cover_state_repr(lid_sensor_filtered));
+
+    if( lid_sensor_filtered != COVER_UNDEF && lid_sensor_feedback ) {
+        if( lid_sensor_filtered == COVER_OPEN )
+            datapipe_exec_full(&ngfd_event_request_pipe, "lid_open");
+        else if( lid_sensor_filtered == COVER_CLOSED )
+            datapipe_exec_full(&ngfd_event_request_pipe, "lid_close");
+    }
 
     /* TODO: On devices that have means to detect physically covered
      *       display, it might be desirable to also power off:
@@ -5108,6 +5119,10 @@ static void tklock_setting_cb(GConfClient *const gcc, const guint id,
         lid_sensor_enabled = gconf_value_get_bool(gcv) ? 1 : 0;
         tklock_lidfilter_rethink_lid_state();
     }
+    else if( id == lid_sensor_feedback_setting_id ) {
+        // Note: affects only processing of future sensor changes
+        lid_sensor_feedback = gconf_value_get_bool(gcv);
+    }
     else if( id == als_enabled_setting_id ) {
         als_enabled = gconf_value_get_bool(gcv);
         tklock_lidfilter_rethink_lid_state();
@@ -5394,6 +5409,12 @@ static void tklock_setting_init(void)
                            tklock_setting_cb,
                            &lid_sensor_enabled_setting_id);
 
+    mce_setting_track_bool(MCE_SETTING_TK_LID_SENSOR_FEEDBACK,
+                           &lid_sensor_feedback,
+                           MCE_DEFAULT_TK_LID_SENSOR_FEEDBACK,
+                           tklock_setting_cb,
+                           &lid_sensor_feedback_setting_id);
+
     mce_setting_track_bool(MCE_SETTING_DISPLAY_ALS_ENABLED,
                            &als_enabled,
                            MCE_DEFAULT_DISPLAY_ALS_ENABLED,
@@ -5553,6 +5574,9 @@ static void tklock_setting_quit(void)
 
     mce_setting_notifier_remove(lid_sensor_enabled_setting_id),
         lid_sensor_enabled_setting_id = 0;
+
+    mce_setting_notifier_remove(lid_sensor_feedback_setting_id),
+        lid_sensor_feedback_setting_id = 0;
 
     mce_setting_notifier_remove(als_enabled_setting_id),
         als_enabled_setting_id = 0;

--- a/tklock.h
+++ b/tklock.h
@@ -93,6 +93,13 @@ enum
 # define MCE_SETTING_TK_LID_SENSOR_ENABLED       MCE_SETTING_TK_PATH "/lid_sensor_enabled"
 # define MCE_DEFAULT_TK_LID_SENSOR_ENABLED       true
 
+/** Whether lid sensor events should trigger feedback
+ *
+ * Note: Requires that NGFD events "lid_open" and "lid_close" are configured for the device.
+ */
+# define MCE_SETTING_TK_LID_SENSOR_FEEDBACK      MCE_SETTING_TK_PATH "/lid_sensor_feedback"
+# define MCE_DEFAULT_TK_LID_SENSOR_FEEDBACK      false
+
 /** Whether lid sensor state should be verified with light sensor
  *
  * If enabled, lid sensor state changes are ignored unless they

--- a/tools/mcetool.c
+++ b/tools/mcetool.c
@@ -230,6 +230,8 @@ static bool          xmce_set_filter_lid_als_limit                     (const ch
 static void          xmce_get_filter_lid_als_limit                     (void);
 static bool          xmce_set_lid_sensor_mode                          (const char *args);
 static void          xmce_get_lid_sensor_mode                          (void);
+static bool          xmce_set_lid_sensor_feedback                      (const char *args);
+static void          xmce_get_lid_sensor_feedback                      (void);
 static bool          xmce_set_lid_open_actions                         (const char *args);
 static void          xmce_get_lid_open_actions                         (void);
 static bool          xmce_set_lid_close_actions                        (const char *args);
@@ -4194,6 +4196,33 @@ static void xmce_get_lid_sensor_mode(void)
         printf("%-"PAD1"s %s\n", "Use lid sensor mode:", txt);
 }
 
+/* Set lid_sensor feedback state
+ *
+ * @param args string suitable for interpreting as enabled/disabled
+ */
+static bool xmce_set_lid_sensor_feedback(const char *args)
+{
+        const char *key = MCE_SETTING_TK_LID_SENSOR_FEEDBACK;
+        if( mcetool_handle_common_args(key, args) )
+                return true;
+
+        gboolean val = xmce_parse_enabled(args);
+        return xmce_setting_set_bool(key, val);
+}
+
+/** Get current lid_sensor feedback state from mce and print it out
+ */
+static void xmce_get_lid_sensor_feedback(void)
+{
+        gboolean    val = false;
+        const char *txt = "unknown";
+
+        if( xmce_setting_get_bool(MCE_SETTING_TK_LID_SENSOR_FEEDBACK, &val) )
+                txt = val ? "enabled" : "disabled";
+
+        printf("%-"PAD1"s %s\n", "Use lid sensor feedback:", txt);
+}
+
 /** Lookup table for lid open actions
  */
 static const symbol_t lid_open_actions[] = {
@@ -7030,6 +7059,7 @@ static bool xmce_get_status(const char *args)
         xmce_get_ps_blocks_touch();
         xmce_get_ps_acts_as_lid();
         xmce_get_lid_sensor_mode();
+        xmce_get_lid_sensor_feedback();
         xmce_get_filter_lid_with_als();
         xmce_get_filter_lid_als_limit();
         xmce_get_lid_open_actions();
@@ -7937,6 +7967,16 @@ static const mce_opt_t options[] =
                 .values      = "enabled|disabled",
                         "set the lid sensor mode; valid modes are:\n"
                         "'enabled' and 'disabled'\n"
+        },
+        {
+                .name        = "set-lid-sensor-feedback",
+                .with_arg    = xmce_set_lid_sensor_feedback,
+                .values      = "enabled|disabled",
+                        "set the lid sensor feedback state; valid options are:\n"
+                        "'enabled' and 'disabled'\n"
+                        "\n"
+                        "Note: Requires that device has NGFD side configuration\n"
+                        "       for \"lid_close\" and \"lid_open\"  events.\n"
         },
         {
                 .name        = "set-lid-open-actions",


### PR DESCRIPTION
Trigger "lid_open" and "lid_close" ngfd events on LID sensor changes.

Sending events is disabled by default. Can be enabled with

    mcetool --set-lid-sensor-feedback=enabled

This change persists over mce restarts / device reboots.

Alternatively system default can be changed e.g. via device specific mce configuration file entry

    /system/osso/dsm/locks/lid_sensor_feedback=true

Since tones triggered by these events can have significantly longer duration than events in use so far, mce now cancels ongoing ngfd events instead of skipping new ones.